### PR TITLE
Убрана GeltaStation из пула карт

### DIFF
--- a/Resources/Prototypes/Stories/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Stories/Maps/Pools/default.yml
@@ -28,4 +28,3 @@
   - CorvaxMaus
   - CorvaxIshimura
   - СorvaxFrame
-  - CorvaxGelta


### PR DESCRIPTION
Для "баланса". Ничего более не скажу.