### PR TITLE
esword for the worthy

### DIFF
--- a/Content.Server/Stories/ForTheWorthy/EswordWorthyComponent.cs
+++ b/Content.Server/Stories/ForTheWorthy/EswordWorthyComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.Stories.ForTheWorthy;
+
+[RegisterComponent]
+public sealed partial class EswordWorthyComponent : Component
+{
+}

--- a/Content.Server/Stories/ForTheWorthy/ForTheWorthyComponent.cs
+++ b/Content.Server/Stories/ForTheWorthy/ForTheWorthyComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Damage;
+
+namespace Content.Server.Stories.ForTheWorthy;
+
+[RegisterComponent]
+public sealed partial class ForTheWorthyComponent : Component
+{
+    [DataField("selfDamage", required: true)]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier SelfDamage = default!;
+}

--- a/Content.Server/Stories/ForTheWorthy/ForTheWorthySystem.cs
+++ b/Content.Server/Stories/ForTheWorthy/ForTheWorthySystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.Popups;
+using Content.Shared.Damage;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Server.Stories.ForTheWorthy;
+
+public sealed partial class ForTheWorthySystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ForTheWorthyComponent, MeleeHitEvent>(OnMeleeHitEvent);
+    }
+
+    private void OnMeleeHitEvent(EntityUid uid, ForTheWorthyComponent comp, MeleeHitEvent args)
+    {
+        if (HasComp<EswordWorthyComponent>(args.User))
+            return;
+
+        if ((_damageableSystem.TryChangeDamage(args.User, comp.SelfDamage, false, origin: uid)) != null)
+        {
+            _popup.PopupEntity("Вы не можете справиться с энергетическим оружием и калечите себя!", args.User, args.User);
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1399,6 +1399,7 @@
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
+  - type: EswordWorthy # Stories
 
 - type: entity
   id: MobMonkeySyndicateAgent
@@ -1558,6 +1559,7 @@
     - Syndicate
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
+  - type: EswordWorthy # Stories
 
 - type: entity
   id: MobKoboldSyndicateAgent

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -22,6 +22,7 @@
   - type: NpcFactionMember
     factions:
     - Syndicate
+  - type: EswordWorthy # Stories
 
 - type: entity
   parent: MobHumanSyndicateAgentBase
@@ -83,6 +84,7 @@
   components:
   - type: NukeOperative
   - type: RandomHumanoidAppearance
+  - type: EswordWorthy # Stories
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -103,3 +105,4 @@
   - type: NpcFactionMember
     factions:
     - Syndicate
+  - type: EswordWorthy # Stories

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -49,6 +49,7 @@
       nameSegments:
         - NamesFirstMilitaryLeader
         - NamesLastMilitary
+    - type: EswordWorthy # Stories
 
 
 ## ERT Leader
@@ -87,6 +88,7 @@
       nameSegments:
       - NamesFirstMilitaryLeader
       - NamesLastMilitary
+    - type: EswordWorthy # Stories
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVA
@@ -513,6 +515,7 @@
       nameSegments:
       - NamesFirstMilitary
       - NamesLastMilitary
+    - type: EswordWorthy # Stories
 
 ## Central Command
 
@@ -539,6 +542,7 @@
     - type: Loadout
       prototypes: [ CentcomGear ]
       roleLoadout: [ RoleSurvivalStandard ]
+    - type: EswordWorthy # Stories
 
 ## Syndicate
 
@@ -562,6 +566,7 @@
     - type: Loadout
       prototypes: [SyndicateOperativeGearExtremelyBasic]
       roleLoadout: [ RoleSurvivalSyndicate ]
+    - type: EswordWorthy # Stories
 
 - type: entity
   id: RandomHumanoidSpawnerNukeOp
@@ -579,6 +584,7 @@
     - type: RandomHumanoidAppearance
       randomizeName: false
     - type: NukeOperative
+    - type: EswordWorthy # Stories
 
 - type: entity
   id: RandomHumanoidSpawnerCluwne

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -89,6 +89,18 @@
       map: [ "blade" ]
   - type: Item
     sprite: Objects/Weapons/Melee/e_sword-inhands.rsi
+  - type: ComponentToggler # Stories - start
+    components:
+    - type: Sharp
+    - type: DisarmMalus
+      malus: 0.6
+    - type: Execution
+      doAfterDuration: 4.0
+    - type: ForTheWorthy
+      selfDamage:
+        types:
+          Slash: 6
+          Heat: 12 # Stories - end
 
 - type: entity
   name: energy dagger
@@ -195,6 +207,11 @@
     - type: Contraband
       severity: Syndicate
       allowedDepartments: null
+    - type: ForTheWorthy # Stories - start
+      selfDamage:
+        types:
+          Slash: 4
+          Heat: 8 # Stories - end
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -68,3 +68,7 @@
     quickEquip: false
     slots:
     - back
+  - type: ForTheWorthy # Stories - start
+    selfDamage:
+      types:
+        Slash: 12 # Stories - end

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -98,6 +98,10 @@
     - Back
     - Belt
   - type: Reflect
+  - type: ForTheWorthy # Stories - start
+    selfDamage:
+      types:
+        Slash: 18 # Stories - end
 
 - type: entity
   name: machete

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -223,6 +223,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: EswordWorthy # Stories
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant
@@ -521,6 +522,8 @@
       blacklist:
         components:
         - AntagImmune
+      components: # Stories - start
+      - type: EswordWorthy # Stories - end
       mindComponents:
       - type: TraitorRole
         prototype: TraitorSleeper

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -24,8 +24,9 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
-      # components: # Stories-MRP
-      # - type: Pacified # Stories-MRP
+      components:
+      - type: EswordWorthy # Stories - start
+      # - type: Pacified # Stories - end
       mindComponents:
       - type: ThiefRole
         prototype: Thief

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,6 +114,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: EswordWorthy # Stories
       mindComponents:
       - type: NukeopsRole
         prototype: NukeopsCommander
@@ -132,6 +133,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: EswordWorthy # Stories
       mindComponents:
       - type: NukeopsRole
         prototype: NukeopsMedic
@@ -152,6 +154,7 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: EswordWorthy # Stories
       mindComponents:
       - type: NukeopsRole
         prototype: Nukeops
@@ -189,6 +192,8 @@
         components:
         - AntagImmune
       lateJoinAdditional: true
+      components: # Stories - start
+      - type: EswordWorthy # Stories - end
       mindComponents:
       - type: TraitorRole
         prototype: Traitor
@@ -213,6 +218,7 @@
       components:
       - type: Revolutionary
       - type: HeadRevolutionary
+      - type: EswordWorthy # Stories
       mindComponents:
       - type: RevolutionaryRole
         prototype: HeadRev
@@ -277,7 +283,7 @@
         tableId: CalmPestEventsTable
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
-        
+
 
 - type: entityTable
   id: SpaceTrafficControlTable

--- a/Resources/Prototypes/Stories/GameRules/events.yml
+++ b/Resources/Prototypes/Stories/GameRules/events.yml
@@ -40,6 +40,7 @@
       - type: Force
       - type: ForceUser
         preset: Inquisitor
+      - type: EswordWorthy
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant
@@ -138,6 +139,7 @@
       - type: Force
       - type: ForceUser
         preset: Inquisitor
+      - type: EswordWorthy
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant

--- a/Resources/Prototypes/Stories/Roles/Jobs/Command/jedi_nt.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/Command/jedi_nt.yml
@@ -30,6 +30,7 @@
     - type: Force
     - type: ForceUser
       preset: Jedi
+    - type: EswordWorthy
 
 - type: startingGear
   id: JediNtGear

--- a/Resources/Prototypes/Stories/Roles/Jobs/Prison/prisoner.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/Prison/prisoner.yml
@@ -13,6 +13,7 @@
   - !type:AddComponentSpecial
     components:
     - type: Prisoner
+    - type: EswordWorthy
 
 - type: startingGear
   id: PRISONPrisoner


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Есворд теперь могут юзать только "достойные" - это агенты, воры (мб убрать воров?), хедревы, ниндзя, инквизитор, оперы, всевозможные подкрепы синдиката, ЦК/ДСО, зеки, страж.
Да, тут нет тенеморфов и нулевых. Нет, я не забыл. Это фича. Честно.
(нулевых я реально забыл да и пофиг на них, а с тенеморфами реально фича)
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Просто реализация навыка в механическом виде. Меньше нагрузка на модеров в плане разбора жалоб, ибо люди не будут юзать есворд на лоупопе по причине "модеры не видят", да и в плане ахелпов, особенно при ЯО.
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Серверная система ForTheWorthySystem слушает событие OnMeleeHit на оружиях с компонентом ForTheWorthy, и если событие вызвал человек без компонента EswordWorthy, наносит ему урон.
Урон определяется через компонент ForTheWorthy на самом оружии.
Сами цифры я проставил от балды.
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->
https://youtu.be/R_Hf3DJIbZU
Я забыл показать ЦК/ДСО, спящих агентов и зеков. Но спящих и роли ЦК (кроме ПЦК, но у них везде одинаковый код) я проверял за кадром.
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->

<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.-->
:cl: pheenty
- add: Теперь использование энергооружия без соответствующего навыка карается самой игрой, нанесением урона по себе.