### PR TITLE
Fix for issuing multiple items

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -29,7 +29,6 @@
     eyes: ClothingEyesGlassesSecurity
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltHolsterFilled
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -29,6 +29,7 @@
     eyes: ClothingEyesGlassesSecurity
     id: DetectivePDA
     ears: ClothingHeadsetSecurity
+    #belt: ClothingBeltHolsterFilled # Stories
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Stories/Roles/Jobs/Command/iaa.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/Command/iaa.yml
@@ -39,7 +39,6 @@
     - BriefcaseBrown
   storage:
     back:
-    - BoxSurvival
     - Paper
     - Paper
     - PenCentcom


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Исправил баг/фичу выдачи двух авариек АВД. Так же пофиксил выдачу детективу дополнительной плечевой кобуры.
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Ибо у дека два пистолета, а у АВД два медипена баллона и тд.
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Убрал строку выдачи с гира.

- [Х] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре.
До фикса:
![Снимок экрана 2024-10-24 025214](https://github.com/user-attachments/assets/dc4855a6-87fe-4a6c-9ccf-e00caa3a475b)
 После фикса:
 ![изображение_2024-10-24_030147225](https://github.com/user-attachments/assets/8c6774d8-de01-4147-8d29-2c841930b6f1)
 Скрины дека предоставить увы не могу. Но плечевая кобура появляется под деком.
**Changelog**
:cl:
- fix: Выдача дополнительного аварийного набора АВД!
- fix: Выдача дополнительной плечевой кобуры детективу!
