### PR TITLE
shadowling veil toggles unpoweredflashlight

### DIFF
--- a/Content.Server/Stories/Shadowling/ShadowlingSystem.Actions.cs
+++ b/Content.Server/Stories/Shadowling/ShadowlingSystem.Actions.cs
@@ -174,8 +174,10 @@ public sealed partial class ShadowlingSystem
         {
             if (HasComp<PoweredLightComponent>(ent))
                 _poweredLight.TryDestroyBulb(ent);
-            else if (TryComp<HandheldLightComponent>(ent, out var comp))
-                _handheldLight.TurnOff((ent, comp));
+            else if (TryComp<HandheldLightComponent>(ent, out var HandheldLight))
+                _handheldLight.TurnOff((ent, HandheldLight));
+            else if (TryComp<UnpoweredFlashlightComponent>(ent, out var UnpoweredFlashlight))
+                _unpoweredFlashlight.SetLight(ent, false, ent, true);
         }
 
         args.Handled = true;

--- a/Content.Server/Stories/Shadowling/ShadowlingSystem.cs
+++ b/Content.Server/Stories/Shadowling/ShadowlingSystem.cs
@@ -15,6 +15,7 @@ using Content.Server.Stories.Photosensitivity;
 using Content.Server.Stunnable;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Light.EntitySystems;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Stories.Shadowling;
 using Content.Shared.Weapons.Ranged.Events;
@@ -36,6 +37,7 @@ public sealed partial class ShadowlingSystem : EntitySystem
     [Dependency] private readonly SmokeSystem _smoke = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly HandheldLightSystem _handheldLight = default!;
+    [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Пелена тенеморфа выключает UnpoweredFlashlight (фонарики в кпк)
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Фикс
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Помимо компонентов PoweredLight и HandheldLight, OnVeilEvent проверяет также и UnpoweredFlashlight и пытается его выключить.
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->

<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.-->
:cl: pheenty
- fix: Способность тенеморфа "Пелена" теперь выключает фонарики в КПК.