### PR TITLE
Return cat parts for human

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -1,4 +1,27 @@
 - type: marking
+  id: CatEars
+  bodyPart: HeadTop # Stories
+  markingCategory: HeadTop # Stories
+  speciesRestriction: [Human]
+  coloring:
+    default:
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SkinColoring
+    layers:
+      ears_cat_inner:
+        type:
+          !type:SimpleColoring
+            color: "#FFFFFF"
+  sprites:
+  - sprite: Mobs/Customization/cat_parts.rsi
+    state: ears_cat_outer
+  - sprite: Mobs/Customization/cat_parts.rsi
+    state: ears_cat_inner
+
+- type: marking
   id: CatTail
   bodyPart: Tail
   markingCategory: Tail

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/ears.yml
@@ -8,26 +8,3 @@
   sprites:
   - sprite: Mobs/Customization/ears.rsi
     state: long_ears
-
-- type: marking
-  id: CatEars
-  bodyPart: HeadTop
-  markingCategory: HeadTop
-  speciesRestriction: [Human]
-  coloring:
-    default:
-      type:
-        !type:CategoryColoring
-          category: Hair
-      fallbackTypes:
-        - !type:SkinColoring
-    layers:
-      ears_cat_inner:
-        type:
-          !type:SimpleColoring
-            color: "#FFFFFF"
-  sprites:
-  - sprite: Mobs/Customization/cat_parts.rsi
-    state: ears_cat_outer
-  - sprite: Mobs/Customization/cat_parts.rsi
-    state: ears_cat_inner

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -23,6 +23,7 @@
     FacialHair: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
     Chest: MobHumanTorso
+    Tail: MobHumanoidAnyMarking # Stories
     Eyes: MobHumanoidEyes
     HeadTop: MobHumanoidAnyMarking
     LArm: MobHumanLArm
@@ -50,7 +51,7 @@
       points: 1
       required: false
     Tail: # the cat tail joke
-      points: 0
+      points: 1 # Stories
       required: false
     HeadTop:
       points: 1


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->
## О PR
<!-- Что вы изменили в этом PR? -->
После какого-то из апстримов слетела модификация кода от Корвакса, позволявшая брать людям кошачьи части в чертах внешности. После [M1and1B](https://github.com/M1and1B) перенёс кошачьи уши в файл с человеческими ушами в ПРе https://github.com/Space-Stories/space-station-14/pull/99, чтобы они стали видимы, но хвосты не вернул 

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
* Вернул кошачьи уши в файл cat_parts
* Сменил категорию ушей, чтобы они стали видимы
* В MobHumanSprites вернул "Tail: MobHumanoidAnyMarking", а также добавил поинт на то чтобы взять хвост
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->
![Content Client_O02mliymOv](https://github.com/user-attachments/assets/c9e29026-71db-480c-b2fe-9f3d71a8331f)
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->

:cl: Shegare
- tweak: Возвращены кошачьи части в чертах внешности людей
