### PR TITLE
Лужи с водой теперь более прозрачные

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -370,7 +370,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             // Kinda EH
             // Could potentially do alpha per-solution but future problem.
 
-            color = solution.GetColorWithout(_prototypeManager, _nonStandardReagents); // Changed _standoutReagents to _nonStandardReagents.
+            color = solution.GetColorWithout(_prototypeManager, _nonStandardReagents); // Changed _standoutReagents to _nonStandardReagents. Stories
             color = color.WithAlpha(0.7f);
 
             foreach (var standout in _standoutReagents)
@@ -394,7 +394,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(transparent).SubstanceColor.WithAlpha(0.15f), interpolateValue);
             }
-            // to here/.
+            // to here.
         }
 
         _appearance.SetData(uid, PuddleVisuals.CurrentVolume, volume.Float(), appearance);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -64,7 +64,12 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [ValidatePrototypeId<ReagentPrototype>]
     private const string CopperBlood = "CopperBlood";
 
+    [ValidatePrototypeId<ReagentPrototype>]
+    private const string Water = "Water";
+
     private static string[] _standoutReagents = [Blood, Slime, CopperBlood];
+    private static string[] _transparentReagents = [Water];
+    private static string[] _nonStandardReagents = (_standoutReagents = _transparentReagents);
 
     public static readonly float PuddleVolume = 1000;
 
@@ -365,7 +370,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             // Kinda EH
             // Could potentially do alpha per-solution but future problem.
 
-            color = solution.GetColorWithout(_prototypeManager, _standoutReagents);
+            color = solution.GetColorWithout(_prototypeManager, _nonStandardReagents);
             color = color.WithAlpha(0.7f);
 
             foreach (var standout in _standoutReagents)
@@ -377,6 +382,16 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 var interpolateValue = quantity.Float() / solution.Volume.Float();
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(standout).SubstanceColor, interpolateValue);
+            }
+            foreach (var transparent in _transparentReagents)
+            {
+                var quantity = solution.GetTotalPrototypeQuantity(transparent);
+                if (quantity <= FixedPoint2.Zero)
+                    continue;
+
+                var interpolateValue = quantity.Float() / solution.Volume.Float();
+                color = Color.InterpolateBetween(color,
+                    _prototypeManager.Index<ReagentPrototype>(transparent).SubstanceColor.WithAlpha(0.15f), interpolateValue);
             }
         }
 

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -64,7 +64,12 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [ValidatePrototypeId<ReagentPrototype>]
     private const string CopperBlood = "CopperBlood";
 
+    [ValidatePrototypeId<ReagentPrototype>]
+    private const string Water = "water";
+
     private static string[] _standoutReagents = [Blood, Slime, CopperBlood];
+
+    private static string[] _transparentReagents = [Water];
 
     public static readonly float PuddleVolume = 1000;
 
@@ -355,6 +360,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         var volume = FixedPoint2.Zero;
         Color color = Color.White;
+        Color color1 = Color.White;
 
         if (_solutionContainerSystem.ResolveSolution(uid, puddleComponent.SolutionName, ref puddleComponent.Solution,
                 out var solution))
@@ -377,6 +383,20 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 var interpolateValue = quantity.Float() / solution.Volume.Float();
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(standout).SubstanceColor, interpolateValue);
+            }
+
+            color1 = solution.GetColorWithout(_prototypeManager, _transparentReagents);
+            color1 = color.WithAlpha(0.2f);
+
+            foreach (var transparent in _transparentReagents)
+            {
+                var quantity = solution.GetTotalPrototypeQuantity(transparent);
+                if (quantity <= FixedPoint2.Zero)
+                    continue;
+
+                var interpolateValue = quantity.Float() / solution.Volume.Float();
+                color = Color.InterpolateBetween(color1,
+                    _prototypeManager.Index<ReagentPrototype>(transparent).SubstanceColor, interpolateValue);
             }
         }
 

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -64,12 +64,12 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [ValidatePrototypeId<ReagentPrototype>]
     private const string CopperBlood = "CopperBlood";
 
-    [ValidatePrototypeId<ReagentPrototype>]
-    private const string Water = "Water";
+    [ValidatePrototypeId<ReagentPrototype>] // Stories
+    private const string Water = "Water";   // Stories
 
     private static string[] _standoutReagents = [Blood, Slime, CopperBlood];
-    private static string[] _transparentReagents = [Water];
-    private static string[] _nonStandardReagents = (_standoutReagents = _transparentReagents);
+    private static string[] _transparentReagents = [Water]; //stories
+    private static string[] _nonStandardReagents = (_standoutReagents = _transparentReagents); // Stories
 
     public static readonly float PuddleVolume = 1000;
 
@@ -370,7 +370,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             // Kinda EH
             // Could potentially do alpha per-solution but future problem.
 
-            color = solution.GetColorWithout(_prototypeManager, _nonStandardReagents);
+            color = solution.GetColorWithout(_prototypeManager, _nonStandardReagents); // Changed _standoutReagents to _nonStandardReagents.
             color = color.WithAlpha(0.7f);
 
             foreach (var standout in _standoutReagents)
@@ -383,6 +383,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(standout).SubstanceColor, interpolateValue);
             }
+            // Stories from here
             foreach (var transparent in _transparentReagents)
             {
                 var quantity = solution.GetTotalPrototypeQuantity(transparent);
@@ -393,6 +394,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(transparent).SubstanceColor.WithAlpha(0.15f), interpolateValue);
             }
+            // to here/.
         }
 
         _appearance.SetData(uid, PuddleVisuals.CurrentVolume, volume.Float(), appearance);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -64,12 +64,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [ValidatePrototypeId<ReagentPrototype>]
     private const string CopperBlood = "CopperBlood";
 
-    [ValidatePrototypeId<ReagentPrototype>]
-    private const string Water = "water";
-
     private static string[] _standoutReagents = [Blood, Slime, CopperBlood];
-
-    private static string[] _transparentReagents = [Water];
 
     public static readonly float PuddleVolume = 1000;
 
@@ -360,7 +355,6 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         var volume = FixedPoint2.Zero;
         Color color = Color.White;
-        Color color1 = Color.White;
 
         if (_solutionContainerSystem.ResolveSolution(uid, puddleComponent.SolutionName, ref puddleComponent.Solution,
                 out var solution))
@@ -383,20 +377,6 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 var interpolateValue = quantity.Float() / solution.Volume.Float();
                 color = Color.InterpolateBetween(color,
                     _prototypeManager.Index<ReagentPrototype>(standout).SubstanceColor, interpolateValue);
-            }
-
-            color1 = solution.GetColorWithout(_prototypeManager, _transparentReagents);
-            color1 = color.WithAlpha(0.2f);
-
-            foreach (var transparent in _transparentReagents)
-            {
-                var quantity = solution.GetTotalPrototypeQuantity(transparent);
-                if (quantity <= FixedPoint2.Zero)
-                    continue;
-
-                var interpolateValue = quantity.Float() / solution.Volume.Float();
-                color = Color.InterpolateBetween(color1,
-                    _prototypeManager.Index<ReagentPrototype>(transparent).SubstanceColor, interpolateValue);
             }
         }
 

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -438,7 +438,7 @@
   slippery: true
   physicalDesc: reagent-physical-desc-translucent
   flavor: water
-  color: "#75b1f020"
+  color: "#75b1f0"
   recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -438,7 +438,7 @@
   slippery: true
   physicalDesc: reagent-physical-desc-translucent
   flavor: water
-  color: "#75b1f0"
+  color: "#75b1f020"
   recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Увеличил прозрачность луж
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
https://discord.com/channels/1111698541841240164/1150207578056441968/1303108853965262891
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
По умолчанию непрозрачность лужи 0.7. был цикл, который для каждого непрозрачного вещества выводил среднее значение между лужей с её цветом и непрозрачностью 0.7 и полностью непрозрачным веществом.

Я добавил после него аналогичный цикл который прогоняет для прозрачных веществ и дает им прозрачность 0.15.
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->
![image](https://github.com/user-attachments/assets/a2b6fe44-0173-4e81-8470-0aabfdf1a599)

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->

Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- tweak: Увеличена прозрачность луж с водой