### PR TITLE
clothingwhitelist tweaks

### DIFF
--- a/Content.Server/Stories/ClothingWhitelist/ClothingWhitelistSystem.cs
+++ b/Content.Server/Stories/ClothingWhitelist/ClothingWhitelistSystem.cs
@@ -1,12 +1,13 @@
-using Content.Shared.Popups;
-using Content.Shared.Inventory.Events;
-using Content.Shared.Explosion.Components;
-using Content.Shared.Emag.Systems;
-using Content.Shared.NPC.Prototypes;
-using Content.Shared.NPC.Components;
-using Content.Shared.NPC.Systems;
-using Content.Shared.Whitelist;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.Forensics;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Explosion.Components;
+using Content.Shared.Inventory.Events;
+using Content.Shared.NPC.Components;
+using Content.Shared.NPC.Prototypes;
+using Content.Shared.NPC.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Whitelist;
 using System.Linq;
 
 namespace Content.Server.Stories.ClothingWhitelist;
@@ -28,6 +29,8 @@ public sealed class ClothingWhitelistSystem : EntitySystem
 
     private void OnEquipped(EntityUid uid, ClothingWhitelistComponent comp, GotEquippedEvent args)
     {
+        if (!HasComp<DnaComponent>(args.Equipee)) return;
+
         if (_whitelistSystem.IsBlacklistFailOrNull(comp.Blacklist, args.Equipee) && _whitelistSystem.IsWhitelistPass(comp.Whitelist, args.Equipee)) return;
 
         if (TryComp<NpcFactionMemberComponent>(args.Equipee, out var npc))

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -100,7 +100,7 @@
       - Energy
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]
+  parent: [ ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband, BaseSyndicateExplodingClothing ] # [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ] # Stories
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -475,21 +475,11 @@
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband ]
+  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband, BaseSyndicateExplodingClothing ] # [ ClothingOuterHardsuitBase, BaseSyndicateContraband ] # Stories
   id: ClothingOuterHardsuitSyndie
   name: blood-red hardsuit
   description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
   components:
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit (doublechest) - start
-    factionsWhitelist:
-    - Syndicate
-  - type: Explosive
-    explosionType: PowerSink
-    maxIntensity: 8
-    intensitySlope: 5
-    totalIntensity: 5
-    canCreateVacuum: false
-  - type: ExplodeOnTrigger # Stories-ExplodingHardsuit (doublechest) - end
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: Item
@@ -542,21 +532,11 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband, BaseSyndicateExplodingClothing ] # [ ClothingOuterHardsuitBase, BaseSyndicateContraband ] # Stories
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit
   description: An elite version of the blood-red hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders.
   components:
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit (doublechest) - start
-    factionsWhitelist:
-    - Syndicate
-  - type: Explosive
-    explosionType: PowerSink
-    maxIntensity: 8
-    intensitySlope: 5
-    totalIntensity: 5
-    canCreateVacuum: false
-  - type: ExplodeOnTrigger # Stories-ExplodingHardsuit (doublechest) - end
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndieelite.rsi
   - type: Clothing
@@ -591,21 +571,11 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband, BaseSyndicateExplodingClothing ] # [ ClothingOuterHardsuitBase, BaseSyndicateContraband ] # Stories
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
   components:
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit (doublechest) - start
-    factionsWhitelist:
-    - Syndicate
-  - type: Explosive
-    explosionType: PowerSink
-    maxIntensity: 8
-    intensitySlope: 5
-    totalIntensity: 5
-    canCreateVacuum: false
-  - type: ExplodeOnTrigger # Stories-ExplodingHardsuit (doublechest) - end
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndiecommander.rsi
   - type: Clothing
@@ -633,21 +603,11 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
+  parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband, BaseSyndicateExplodingClothing ] # [ ClothingOuterHardsuitBase, BaseSyndicateContraband ] # Stories
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit made by the cutting edge R&D department at cybersun to be hyper resilient.
   components:
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit (doublechest) - start
-    factionsWhitelist:
-    - Syndicate
-  - type: Explosive
-    explosionType: PowerSink
-    maxIntensity: 8
-    intensitySlope: 5
-    totalIntensity: 5
-    canCreateVacuum: false
-  - type: ExplodeOnTrigger # Stories-ExplodingHardsuit (doublechest) - end
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/cybersun.rsi
   - type: Clothing
@@ -803,7 +763,7 @@
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander ]
+  parent: [ BaseERTNotExplodingClothing, BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander ] # [ BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander ] # Stories
   id: ClothingOuterHardsuitERTLeader
   name: ERT leader's hardsuit
   description: A protective hardsuit worn by the leader of an emergency response team.
@@ -831,12 +791,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit
-    factionsWhitelist: null
 
 #ERT Chaplain Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitJuggernaut ]
+  parent: [ BaseERTNotExplodingClothing, BaseCentcommContraband, ClothingOuterHardsuitJuggernaut ] # [ BaseCentcommContraband, ClothingOuterHardsuitJuggernaut ] # Stories
   id: ClothingOuterHardsuitERTChaplain
   name: ERT chaplain's hardsuit
   description: A protective hardsuit worn by the chaplains of an Emergency Response Team.
@@ -847,8 +805,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTChaplain
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit
-    factionsWhitelist: null
 
 #ERT Engineer Hardsuit
 - type: entity
@@ -866,7 +822,7 @@
 
 #ERT Medic Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ]
+  parent: [ BaseERTNotExplodingClothing, BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ] # [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ] # Stories
   id: ClothingOuterHardsuitERTMedical
   name: ERT medic's hardsuit
   description: A protective hardsuit worn by the medics of an emergency response team.
@@ -877,12 +833,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTMedical
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit
-    factionsWhitelist: null
 
 #ERT Security Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie ]
+  parent: [ BaseERTNotExplodingClothing, BaseCentcommContraband, ClothingOuterHardsuitSyndie ] # [ BaseCentcommContraband, ClothingOuterHardsuitSyndie ] # Stories
   id: ClothingOuterHardsuitERTSecurity
   name: ERT security's hardsuit
   description: A protective hardsuit worn by the security officers of an emergency response team.
@@ -914,8 +868,6 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-  - type: ClothingWhitelist # Stories-ExplodingHardsuit
-    factionsWhitelist: null
 
 #ERT Janitor Hardsuit
 - type: entity

--- a/Resources/Prototypes/Stories/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Stories/Entities/Clothing/base_clothing.yml
@@ -1,0 +1,22 @@
+- type: entity
+  abstract: true
+  id: BaseSyndicateExplodingClothing
+  components:
+  - type: ClothingWhitelist
+    factionsWhitelist:
+    - Syndicate
+  - type: Explosive
+    explosionType: PowerSink
+    maxIntensity: 8
+    intensitySlope: 5
+    totalIntensity: 5
+    canCreateVacuum: false
+  - type: ExplodeOnTrigger
+
+- type: entity
+  abstract: true
+  id: BaseERTNotExplodingClothing
+  components:
+  - type: ClothingWhitelist
+    factionsWhitelist: null
+  - type: Emagged # Нельзя емагнуть скафандр без биокода, если он уже емагнут.


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
1) скафандры яо не взрываются на существах без dnacomponent, например на манекенах.
2) рейдерский костюм теперь тоже взрывается.
3) скафандры ОБР больше нельзя емагнуть, ничего не сделав и просто потратив заряд. формально они просто емагнуты изначально. хотя я почти уверен, что никто и не знал, что по ним можно нажать емагом.
4) вместо прописывания взрыва в каждом скафандре яо теперь есть BaseSyndicateExplodingClothing. вместо прописывания null вайтлиста в скафандрах ОБР теперь есть BaseERTNotExplodingClothing
5) using в ClothingWhitelistSystem отсортированы по алфавиту
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
1) по просьбам мапперов, по факту фикс
2) по факту фикс
3) фикс, хоть и костыльный
4) упрощение кода
5) да
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
нет
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->

<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.-->
:cl: pheenty
- add: Рейдерский костюм Синдиката теперь тоже имеет биокод.
- fix: Скафандры ЯО больше не взрываются на манекенах.
